### PR TITLE
Add MSTest project and PathHelpers unit tests

### DIFF
--- a/CultureList.Tests/CultureList.Tests.csproj
+++ b/CultureList.Tests/CultureList.Tests.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="MSTest.Sdk/4.3.3">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Platforms>x64</Platforms>
+    <PlatformTarget>x64</PlatformTarget>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="MSTest" Version="4.3.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CultureList\CultureList.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/CultureList.Tests/Helpers/PathHelpersTests.cs
+++ b/CultureList.Tests/Helpers/PathHelpersTests.cs
@@ -1,0 +1,33 @@
+﻿// add using directives for the class to be tested
+using CultureList.Helpers;
+
+namespace CultureList.Tests.Helpers;
+
+// Add TestClass attribute to the class
+[TestClass]
+public class PathHelpersTests
+{
+    // Add TestMethod attribute to the method
+    // Method name should describe the test scenario in the format MethodName_Scenario_ExpectedResult
+    [TestMethod]
+    public void AnonymizePath_IsUserProfilePath_AnonymizedPath()
+    {
+        string result = PathHelpers.AnonymizePath("C:\\Users\\kenne\\Documents\\file.txt");
+        Assert.AreEqual("%USERPROFILE%\\Documents\\file.txt", result);
+    }
+
+    [TestMethod]
+    public void AnonymizePath_IsUserProfilePath_AnonymizePathNotSame()
+    {
+        var result = PathHelpers.AnonymizePath("C:\\Users\\kenne\\Documents\\file.txt");
+        Assert.AreNotEqual("C:\\users\\kenne\\Documents\\file.txt", result);
+    }
+
+
+    [TestMethod]
+    public void AnonymizePath_NotUserProfilePath_NotAnonymized()
+    {
+        var result = PathHelpers.AnonymizePath("C:\\Users\\public\\Documents\\file.txt");
+        Assert.AreNotEqual("%USERPROFILE%\\Documents\\file.txt", result);
+    }
+}

--- a/CultureList.slnx
+++ b/CultureList.slnx
@@ -2,6 +2,7 @@
   <Configurations>
     <Platform Name="x64" />
   </Configurations>
+  <Project Path="CultureList.Tests/CultureList.Tests.csproj" Id="59edc078-9cff-4d1f-a4bb-835ff41c3ac8" />
   <Project Path="CultureList/CultureList.csproj">
     <Platform Project="x64" />
   </Project>

--- a/CultureList/CultureList.csproj
+++ b/CultureList/CultureList.csproj
@@ -81,5 +81,9 @@
     <Message Importance="high" Text="The obj folder has been deleted." />
     <RemoveDir Directories="$(BaseIntermediateOutputPath)" />
   </Target>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="CultureList.Tests" />
+  </ItemGroup>
   
 </Project>


### PR DESCRIPTION
Add MSTest project and PathHelpers unit tests

- Added CultureList.Tests MSTest project targeting .NET 10.0 (Windows x64), referencing main project and MSTest package.
- Introduced PathHelpersTests.cs for AnonymizePath unit tests.
- Updated solution and exposed internals to tests via InternalsVisibleTo.