### PR TITLE
Update Architecture property and improve code comments

### DIFF
--- a/CultureList/Helpers/AppInfo.cs
+++ b/CultureList/Helpers/AppInfo.cs
@@ -8,6 +8,23 @@ namespace CultureList.Helpers;
 public static class AppInfo
 {
     /// <summary>
+    /// Returns the process architecture e.g. x64, Arm64, etc.
+    /// </summary>
+    public static string Architecture
+    {
+        get
+        {
+            field = RuntimeInformation.ProcessArchitecture.ToString();
+            return field.ToLowerInvariant() switch
+            {
+                "x64" => "x64",
+                "x86" => "x86",
+                _ => field
+            };
+        }
+    }
+
+    /// <summary>
     /// Returns the Copyright info from the Assembly info
     /// </summary>
     public static string AppCopyright => FileVersionInfo.GetVersionInfo(Assembly.GetEntryAssembly()!.Location).LegalCopyright ?? "missing";
@@ -20,7 +37,7 @@ public static class AppInfo
     /// <summary>
     /// Returns the app's name without the extension
     /// </summary>
-    public static string AppName => Assembly.GetEntryAssembly()!.GetName().Name ?? "missing";
+    public static string AppName => (Assembly.GetEntryAssembly()!.GetName().Name) ?? "missing";
 
     /// <summary>
     /// Returns the app's full path including the EXE name
@@ -40,17 +57,13 @@ public static class AppInfo
     /// <summary>
     /// Returns the product version from the Assembly info
     /// </summary>
+    // Used in About window XAML tooltip: Views/AboutPage.xaml.
     public static string AppProductVersion => FileVersionInfo.GetVersionInfo(Assembly.GetEntryAssembly()!.Location).ProductVersion ?? "missing";
 
     /// <summary>
     /// Returns the full version number as Version
     /// </summary>
     public static Version AppVersionVer => Assembly.GetEntryAssembly()!.GetName().Version!;
-
-    /// <summary>
-    /// Returns the process architecture e.g. X64, Arm64, etc.
-    /// </summary>
-    public static string Architecture => RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
 
     /// <summary>
     /// True if running as administrator


### PR DESCRIPTION
Update Architecture property and improve code comments

- Refactored the Architecture property to normalize the process architecture string to lower case and map "x64" and "x86" to themselves; other values return as-is.
- Removed the previous Architecture property implementation that only returned the architecture in lower case.
- Added a comment to AppProductVersion to clarify its use in the About window XAML tooltip.
- Made a minor formatting change to AppName by adding parentheses (no functional impact).