### PR TITLE
Refactor global usings and clean up ClipboardHelper

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,8 @@
+## Commit Message Format
+
+- The commit message should have a short description (50 characters or less) followed by a blank line and then a longer description.
+- The short description should be in the imperative mood (e.g., "Fix bug" or "Add feature").
+- The longer description should provide additional context about the change, including any relevant background information, the motivation for the change, and any potential impact on the project.
+- The longer description should use bullet points to organize information and make it easier to read.
+- Reference any related issues or pull requests at the end of the long description. If no related issues or pull requests exist, you can omit this section.
+- If the commit fixes an issue or task, include Fixes #<issue-number> or Closes #<issue-number> at the end of the long description. 

--- a/CultureList.slnx
+++ b/CultureList.slnx
@@ -2,8 +2,11 @@
   <Configurations>
     <Platform Name="x64" />
   </Configurations>
-  <Project Path="CultureList.Tests/CultureList.Tests.csproj" Id="59edc078-9cff-4d1f-a4bb-835ff41c3ac8" />
   <Project Path="CultureList/CultureList.csproj">
+    <Platform Project="x64" />
+  </Project>
+  <Project Path="CultureList.Tests/CultureList.Tests.csproj"
+           Id="59edc078-9cff-4d1f-a4bb-835ff41c3ac8">
     <Platform Project="x64" />
   </Project>
 </Solution>

--- a/CultureList/GlobalUsings.cs
+++ b/CultureList/GlobalUsings.cs
@@ -9,7 +9,6 @@ global using System.IO;
 global using System.Linq;
 global using System.Reflection;
 global using System.Runtime.InteropServices;
-global using System.Runtime.Versioning;
 global using System.Security.Principal;
 global using System.Text;
 global using System.Text.Json;
@@ -21,6 +20,7 @@ global using System.Windows.Data;
 global using System.Windows.Input;
 global using System.Windows.Media;
 global using System.Windows.Markup;
+global using System.Windows.Threading;
 
 global using CommunityToolkit.Mvvm.ComponentModel;
 global using CommunityToolkit.Mvvm.Input;

--- a/CultureList/Helpers/ClipboardHelper.cs
+++ b/CultureList/Helpers/ClipboardHelper.cs
@@ -1,12 +1,9 @@
 ﻿// Copyright (c) Tim Kennedy. All Rights Reserved. Licensed under the MIT License.
 
-using System.Windows.Threading;
-
 namespace CultureList.Helpers;
 
 internal static class ClipboardHelper
 {
-    #region Copy text to clipboard
     /// <summary>
     /// Copy to clipboard with retry logic to handle potential exceptions when the clipboard is busy.
     /// </summary>
@@ -50,5 +47,4 @@ internal static class ClipboardHelper
 
         return false;
     }
-    #endregion Copy text to clipboard
 }


### PR DESCRIPTION
Refactor global usings and clean up ClipboardHelper

- Sorry, this PR contains multiple updates that should have been in separate PRs
- Added global using directives for System.Diagnostics and System.Windows.Threading in GlobalUsings.cs to centralize common imports.
- Removed global using for System.Runtime.Versioning as it is no longer required.
- Updated ClipboardHelper.cs to remove redundant using System.Windows.Threading; due to global import.
- Made minor formatting adjustments in ClipboardHelper.cs for consistency and readability.
- These changes reduce redundancy and ensure consistent namespace imports across the project.

---

Additional commits are for adding copilot-instructions.md and hopefully fixing the solution file that got borked when adding test project.