### PR TITLE
Enhance translations UI with expander and percentage display

### DIFF
--- a/CultureList/Configuration/TempSettings.cs
+++ b/CultureList/Configuration/TempSettings.cs
@@ -16,4 +16,8 @@ internal sealed partial class TempSettings : ConfigManager<TempSettings>
 
     [ObservableProperty]
     private static bool _uIExpanderOpen;
+
+    [ObservableProperty]
+    private static bool _translateExpanderOpen;
+
 }

--- a/CultureList/Helpers/ResourceHelpers.cs
+++ b/CultureList/Helpers/ResourceHelpers.cs
@@ -66,4 +66,46 @@ internal static class ResourceHelpers
         return description.ToString()!;
     }
     #endregion Get a resource string
+
+    #region Compute percentage of language strings
+    /// <summary>
+    /// Compute percentage of strings by dividing the number of strings
+    /// for the supplied language by the total of en-US strings.
+    /// </summary>
+    /// <param name="language">Language code</param>
+    /// <returns>The percentage with no decimal places as a string. Includes the "%".</returns>
+    public static string GetLanguagePercent(string language)
+    {
+        ResourceDictionary dictionary = [];
+        try
+        {
+            dictionary.Source = new Uri($"Languages/Strings.{language}.xaml", UriKind.RelativeOrAbsolute);
+            int totalCount = GetTotalDefaultLanguageCount();
+            if (totalCount == 0)
+            {
+                _log.Error("GetLanguagePercent totalCount is 0 for default dictionary");
+                return GetStringResource("MsgText_Error_Caption");
+            }
+            if (dictionary.Count == 0)
+            {
+                _log.Error($"GetLanguagePercent Count is 0 for {dictionary.Source}");
+                return GetStringResource("MsgText_Error_Caption");
+            }
+            double percent = (double)dictionary.Count / totalCount;
+            percent = Math.Min(percent, 1.0);  // Cap at 100%
+            percent = Math.Round(percent, 2, MidpointRounding.ToZero);
+            return percent.ToString("P0", CultureInfo.InvariantCulture);
+        }
+        catch (IOException ex)
+        {
+            _log.Error(ex, $"IO exception in GetLanguagePercent for {dictionary.Source}");
+            return GetStringResource("MsgText_Error_Caption");
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, $"Error in GetLanguagePercent for {dictionary.Source}");
+            return GetStringResource("MsgText_Error_Caption");
+        }
+    }
+    #endregion Compute percentage of language strings
 }

--- a/CultureList/Styles/DataGridStyles.xaml
+++ b/CultureList/Styles/DataGridStyles.xaml
@@ -58,4 +58,13 @@
     </Style>
     <!--#endregion-->
 
+    <!--#region Right align cell text-->
+    <Style TargetType="DataGridCell"
+           x:Key="AlignColumnRight"
+           BasedOn="{StaticResource {x:Type DataGridCell}}">
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="HorizontalAlignment" Value="Right" />
+    </Style>
+    <!--#endregion-->
+
 </ResourceDictionary>

--- a/CultureList/ViewModels/AboutViewModel.cs
+++ b/CultureList/ViewModels/AboutViewModel.cs
@@ -7,6 +7,16 @@ namespace CultureList.ViewModels;
 /// </summary>
 internal sealed partial class AboutViewModel
 {
+    #region Constructor
+    public AboutViewModel()
+    {
+        if (AnnotatedLanguageList.Count == 0)
+        {
+            AddNote();
+        }
+    }
+    #endregion Constructor
+
     #region Relay Commands
     [RelayCommand]
     private static void ViewLicense()
@@ -23,7 +33,7 @@ internal sealed partial class AboutViewModel
     }
 
     [RelayCommand]
-    private static void GoToGitHub(string url)
+    private static void GoToWebPage(string url)
     {
         Process p = new();
         p.StartInfo.FileName = url;
@@ -37,4 +47,24 @@ internal sealed partial class AboutViewModel
         await GitHubHelpers.CheckRelease();
     }
     #endregion Relay Commands
+
+    #region Annotated Language translation list
+    public List<UILanguage> AnnotatedLanguageList { get; } = [];
+    #endregion Annotated Language translation list
+
+    #region Add note to list of languages
+    private void AddNote()
+    {
+        foreach (UILanguage item in UILanguage.DefinedLanguages)
+        {
+            // en-GB is a special case and therefore should not be listed.
+            // See the comments in Languages\Strings.en-GB.xaml.
+            if (item.LanguageCode is not "en-GB")
+            {
+                item.Note = GetLanguagePercent(item.LanguageCode!);
+                AnnotatedLanguageList.Add(item);
+            }
+        }
+    }
+    #endregion Add note to list of languages
 }

--- a/CultureList/Views/AboutPage.xaml
+++ b/CultureList/Views/AboutPage.xaml
@@ -88,7 +88,7 @@
                            HorizontalAlignment="Left"
                            ToolTip="{DynamicResource About_CreatedByToolTip}"
                            ToolTipService.Placement="Top">
-                    <Hyperlink Command="{Binding GoToGitHubCommand}"
+                    <Hyperlink Command="{Binding GoToWebPageCommand}"
                                CommandParameter="https://github.com/Timthreetwelve"
                                Foreground="{DynamicResource MaterialDesign.Brush.Foreground}">
                         <TextBlock Text="Tim Kennedy" TextWrapping="Wrap" />
@@ -145,7 +145,7 @@
                                              Kind="Github" />
                 </StackPanel>
                 <TextBlock Grid.Row="7" Grid.Column="2">
-                    <Hyperlink Command="{Binding GoToGitHubCommand}"
+                    <Hyperlink Command="{Binding GoToWebPageCommand}"
                                CommandParameter="{Binding Path=Text,
                                                           ElementName=TbxGithub}"
                                Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
@@ -184,53 +184,67 @@
                 </TextBlock>
                 <!--#endregion-->
 
-                <!--#region Translations-->
-                <Grid Grid.Row="11" Grid.Column="0">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="26" />
-                        <RowDefinition Height="26" />
-                        <RowDefinition Height="*" />
-                    </Grid.RowDefinitions>
-                    <TextBlock Grid.Row="0"
-                               HorizontalAlignment="Left"
-                               Text="{DynamicResource About_Translations}" />
+                <!--#region Translations expander-->
+                <Expander Grid.Row="11" Grid.Column="0"
+                          Grid.ColumnSpan="3"
+                          Margin="0,10,0,0"
+                          materialDesign:ExpanderAssist.ExpanderButtonPosition="Start"
+                          materialDesign:ExpanderAssist.HorizontalHeaderPadding="5,10"
+                          IsExpanded="{Binding TranslateExpanderOpen,
+                                               Source={x:Static config:TempSettings.Setting}}">
+                    <Expander.Header>
+                        <Grid>
+                            <TextBlock Margin="10,0"
+                                       FontWeight="SemiBold"
+                                       Text="{DynamicResource About_Translations}"
+                                       TextWrapping="Wrap" />
+                        </Grid>
+                    </Expander.Header>
+                    <Grid Margin="40,0,0,0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="20" />
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="20" />
+                        </Grid.RowDefinitions>
 
-                    <TextBlock Grid.Row="1">
-                        <Hyperlink Command="{Binding GoToGitHubCommand}"
-                                   CommandParameter="https://github.com/Timthreetwelve/CultureList/wiki/Contribute-a-Translation"
-                                   Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
-                                   ToolTip="{DynamicResource About_ContributeToolTip}"
-                                   ToolTipService.Placement="Top">
-                            <TextBlock Text="{DynamicResource About_Contribute}" />
-                        </Hyperlink>
-                    </TextBlock>
-                </Grid>
+                        <DataGrid MinWidth="350" Grid.Row="0"
+                                  HorizontalAlignment="Left"
+                                  d:ItemsSource="{d:SampleData ItemCount=4}"
+                                  materialDesign:DataGridAssist.CellPadding="15,5,15,5"
+                                  materialDesign:DataGridAssist.SelectedCellBorderBrush="Transparent"
+                                  AutoGenerateColumns="False"
+                                  Background="{DynamicResource MaterialDesign.Brush.Card.Background}"
+                                  BorderThickness="2"
+                                  HeadersVisibility="None"
+                                  IsReadOnly="True"
+                                  ItemsSource="{Binding AnnotatedLanguageList,
+                                                        Mode=OneWay}">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Binding="{Binding LanguageNative}"
+                                                    MinWidth="130" />
+                                <DataGridTextColumn Binding="{Binding LanguageCode}"
+                                                    MinWidth="60" />
+                                <DataGridTextColumn Binding="{Binding Contributor}"
+                                                    MinWidth="200" />
+                                <DataGridTextColumn Binding="{Binding Note}"
+                                                    MinWidth="90"
+                                                    CellStyle="{StaticResource AlignColumnRight}" />
+                            </DataGrid.Columns>
+                        </DataGrid>
 
-                <Border Grid.Row="11" Grid.Column="2"
-                        Width="auto"
-                        Margin="0,0,20,0"
-                        HorizontalAlignment="Left"
-                        BorderBrush="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}"
-                        BorderThickness="1">
-                    <DataGrid MinWidth="350" MaxHeight="120"
-                              materialDesign:DataGridAssist.CellPadding="{Binding RowSpacing,
-                                                                                  Source={x:Static config:UserSettings.Setting},
-                                                                                  Converter={StaticResource Spacing}}"
-                              materialDesign:DataGridAssist.SelectedCellBorderBrush="Transparent"
-                              AutoGenerateColumns="False"
-                              Background="{DynamicResource MaterialDesign.Brush.Card.Background}"
-                              HeadersVisibility="None"
-                              IsReadOnly="True"
-                              ItemsSource="{x:Static models:UILanguage.DefinedLanguages}">
-                        <DataGrid.Columns>
-                            <DataGridTextColumn Binding="{Binding LanguageNative}"
-                                                MinWidth="80" />
-                            <DataGridTextColumn Binding="{Binding LanguageCode}"
-                                                MinWidth="70" />
-                            <DataGridTextColumn Binding="{Binding Contributor}" />
-                        </DataGrid.Columns>
-                    </DataGrid>
-                </Border>
+                        <TextBlock Grid.Row="2">
+                            <Hyperlink Command="{Binding GoToWebPageCommand}"
+                                       CommandParameter="https://github.com/Timthreetwelve/GetMyIP/wiki/Contribute-a-Translation"
+                                       Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
+                                       ToolTip="{DynamicResource About_ContributeToolTip}"
+                                       ToolTipService.Placement="Top">
+                                <InlineUIContainer>
+                                    <TextBlock Text="{DynamicResource About_Contribute}" />
+                                </InlineUIContainer>
+                            </Hyperlink></TextBlock>
+                    </Grid>
+                </Expander>
                 <!--#endregion-->
             </Grid>
         </ScrollViewer>


### PR DESCRIPTION
Enhance translations UI with expander and percentage display

- Added TranslateExpanderOpen property to TempSettings to control the translations expander state.
- Introduced GetLanguagePercent in ResourceHelpers to compute translation coverage per language.
- Added AlignColumnRight style in DataGridStyles.xaml for right-aligning percentage values.
- Refactored AboutViewModel:
  - Added AnnotatedLanguageList and AddNote for displaying languages with translation percentages.
  - Replaced GoToGitHubCommand with GoToWebPageCommand for general web navigation.
  - Added constructor to initialize AnnotatedLanguageList.
- Updated AboutPage.xaml:
  - Replaced static translations DataGrid with an Expander containing a DataGrid bound to AnnotatedLanguageList.
  - Updated hyperlinks to use GoToWebPageCommand.
  - Improved layout and styling for the translations section.

No related issues or pull requests.